### PR TITLE
Add Sequel to Ruby tools, update Kiba description

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ A curated list of notable ETL (extract, transform, load) frameworks, libraries a
 * http://www.parsely.com/misc/slides/streamparse/notes/
 
 ## Ruby
-* [Kiba](https://github.com/thbar/kiba) - "provides you with a DSL to define ETL jobs"
+* [Kiba](https://github.com/thbar/kiba) - "Data processing & ETL framework for Ruby"
 * [nokogiri](https://github.com/sparklemotion/nokogiri) - an excellent XML parser that "just works"
 * [Square ETL](https://github.com/square/etl)
+* [Sequel](https://github.com/jeremyevans/sequel) - "The Database Toolkit for Ruby"
 
 ## Go
 * [Crunch](https://github.com/jondot/crunch) - "A fast to develop, fast to run, Go based toolkit for ETL and feature extraction on Hadoop."


### PR DESCRIPTION
Particularly since `SQLAlchemy` is referenced in Python, `Sequel` is the equivalent tool in Ruby, and a must-have for any ETL toolkit in Ruby.