### PR TITLE
Add ingestr to Python Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A curated list of notable ETL (extract, transform, load) frameworks, libraries a
 
 ## Python
 ### Libraries
+* [ingestr](https://github.com/bruin-data/ingestr) - CLI tool to copy data between databases with a single command. Supports 50+ sources including Postgres, MySQL, MongoDB, Salesforce, Shopify to any data warehouse.
 * [BeautifulSoup](http://www.crummy.com/software/BeautifulSoup/) - Popular library used to extract data from web pages.
 * [Blaze](https://github.com/blaze/blaze) - "translates a subset of modified NumPy and Pandas-like syntax to databases and other computing systems."
 * [Bonobo](https://www.bonobo-project.org/) - Simple, modern and atomic data transformation graphs for Python 3.5+.


### PR DESCRIPTION
## Summary
- Add [ingestr](https://github.com/bruin-data/ingestr) to the Python Libraries section

ingestr is a CLI tool to copy data between databases with a single command. Supports 50+ sources including Postgres, MySQL, MongoDB, Salesforce, Shopify to any data warehouse.