### PR TITLE
Add DataRaven to Cloud Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Open source tools are strongly preferred. Proprietary or restrictively licensed 
 - [AWS Batch](https://aws.amazon.com/batch/) - "enables developers, scientists, and engineers to easily and efficiently run hundreds of thousands of batch computing jobs on AWS."
 - [AWS Glue](https://aws.amazon.com/glue/) - "a serverless data integration service that makes it easy for analytics users to discover, prepare, move, and integrate data from multiple sources."
 - [Cloud Data Fusion](https://cloud.google.com/data-fusion) - "Fully managed, cloud-native data integration platform."
-- [DataRaven](https://dataraven.io/) - "Managed rclone for cloud object storage."
+- [DataRaven](https://dataraven.io/) - "Managed rclone for cloud object storage transfer workflows."
 - [Fivetran](https://www.fivetran.com/) - "automates data movement from disparate sources into your destination."
 - [Google Dataflow](https://cloud.google.com/products/dataflow) - "Google Cloud Dataflow provides a simple, powerful model for building both batch and streaming parallel data processing pipelines."
 - [Hevo](https://hevodata.com/) - "a no-code data movement platform that is usable by your most technical as well as your non-technical and business users."

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Open source tools are strongly preferred. Proprietary or restrictively licensed 
 - [AWS Batch](https://aws.amazon.com/batch/) - "enables developers, scientists, and engineers to easily and efficiently run hundreds of thousands of batch computing jobs on AWS."
 - [AWS Glue](https://aws.amazon.com/glue/) - "a serverless data integration service that makes it easy for analytics users to discover, prepare, move, and integrate data from multiple sources."
 - [Cloud Data Fusion](https://cloud.google.com/data-fusion) - "Fully managed, cloud-native data integration platform."
+- [DataRaven](https://dataraven.io/) - "a cloud-agnostic data movement platform for managing transfers across storage providers."
 - [Fivetran](https://www.fivetran.com/) - "automates data movement from disparate sources into your destination."
 - [Google Dataflow](https://cloud.google.com/products/dataflow) - "Google Cloud Dataflow provides a simple, powerful model for building both batch and streaming parallel data processing pipelines."
 - [Hevo](https://hevodata.com/) - "a no-code data movement platform that is usable by your most technical as well as your non-technical and business users."

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Open source tools are strongly preferred. Proprietary or restrictively licensed 
 - [AWS Batch](https://aws.amazon.com/batch/) - "enables developers, scientists, and engineers to easily and efficiently run hundreds of thousands of batch computing jobs on AWS."
 - [AWS Glue](https://aws.amazon.com/glue/) - "a serverless data integration service that makes it easy for analytics users to discover, prepare, move, and integrate data from multiple sources."
 - [Cloud Data Fusion](https://cloud.google.com/data-fusion) - "Fully managed, cloud-native data integration platform."
-- [DataRaven](https://dataraven.io/) - "a cloud-agnostic data movement platform for managing transfers across storage providers."
+- [DataRaven](https://dataraven.io/) - "Managed rclone for cloud object storage."
 - [Fivetran](https://www.fivetran.com/) - "automates data movement from disparate sources into your destination."
 - [Google Dataflow](https://cloud.google.com/products/dataflow) - "Google Cloud Dataflow provides a simple, powerful model for building both batch and streaming parallel data processing pipelines."
 - [Hevo](https://hevodata.com/) - "a no-code data movement platform that is usable by your most technical as well as your non-technical and business users."


### PR DESCRIPTION
Adds DataRaven under Cloud Services in alphabetical order.

Why it belongs here:
- It is a cloud data movement platform used for ETL/ELT-style transfer workflows across storage systems.
- This list already includes comparable cloud services for managed data movement.